### PR TITLE
Custom color palette!

### DIFF
--- a/_sass/dogwood/custom-variables.scss
+++ b/_sass/dogwood/custom-variables.scss
@@ -1,0 +1,4 @@
+$background-color: #fcfcfc;
+$dark-background-color: #292938;
+$primary-color: #a9252a;
+$primary-color-alt: #d9a7a9;


### PR DESCRIPTION
The Jekyll theme we're using, [dogwood](https://github.com/osmus/dogwood), comes with a [default color palette](https://github.com/osmus/dogwood/blob/main/_sass/dogwood/initialize.scss) and [a placeholder for custom colors](https://github.com/osmus/dogwood/blob/main/_sass/dogwood/custom-variables.scss). I think it would be nice for MapRVA to use a custom color palette on our website, to differentiate ourselves and to demonstrate dogwood's customizability.

Here is a screenshot of what I have so far. These colors are mostly inspired by the flag/logo featured on the [Richmond's government site](https://www.rva.gov/). I am open to any and all ideas! You can see the current theme on our [live site](https://maprva.org).

![Screenshot from 2024-03-06 14-58-53](https://github.com/MapRVA/maprva.github.io/assets/55111303/43fdbfa6-8fdc-4e81-949e-f83b7e5beb49)