### PR TITLE
Add cemeteries project page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.2",
         "@tailwindcss/typography": "^0.5.19",
-        "astro": "^6.0.4",
-        "maplibre-gl": "^5.20.1",
+        "astro": "^6.0.8",
+        "maplibre-gl": "^5.21.0",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",

--- a/src/content/projects/cemeteries.mdx
+++ b/src/content/projects/cemeteries.mdx
@@ -1,0 +1,28 @@
+---
+title: Richmond Cemetery Mapping
+blurb: Open source mapping of Richmond's resting places using open data
+roles:
+  - person: mike-obrien
+    title: Project Lead
+  - person: john-pole
+    title: Mapper
+  - person: jacob-hall
+    title: Mapper
+---
+import UltraMap from '../../components/UltraMap.astro';
+
+The maps below shows the cemeteries we've mapped in Richmond. This is an ongoing project and we'd love for you to help! Skip to the end to see how.
+
+For more extensive and in-depth mapping, check out the [Richmond Cemetery Collaboratory](https://cemeterycollaboratory.org) (no affiliation).
+
+## Shockoe Hill Cemetery
+<UltraMap name="cemeteries-shockoe-hill" />
+
+## East End and Evergreen Cemeteries
+<UltraMap name="cemeteries-east-ends" />
+
+## Contributing
+Graves can be tagged on OpenStreetMap following the guidance [located here](https://wiki.openstreetmap.org/wiki/Tag:cemetery%3Dgrave).
+Images of the graves can be uploaded to [Wikimedia Commons](https://commons.wikimedia.org) and [tagged on OSM](https://wiki.openstreetmap.org/wiki/Key:wikimedia_commons).
+Street-level imagery via [Mapillary](https://www.mapillary.com/app/?lat=37.54915241212372&lng=-77.51373540000202&z=10.565586644348583) can be a little more involved -- 
+[download their app](https://www.mapillary.com/mobile-apps) or [contact us](https://www.maprva.org/contact), we'd love to walk you through it!

--- a/src/content/ultra-maps/cemeteries-east-ends.ultra
+++ b/src/content/ultra-maps/cemeteries-east-ends.ultra
@@ -1,0 +1,94 @@
+---
+server: https://overpass.maprva.org/api
+options:
+  zoom: 16
+  center: [ -77.388, 37.5335 ]
+  bearing: -80
+style:
+  extends: https://styles.maprva.org/henrico-aerial-imagery-latest.json
+  layers:
+    - type: line
+      paint:
+        line-color: "#FF8303"
+        line-opacity: 0.7
+        line-width: 5
+    - type: symbol
+      filter: [ "==", [ "geometry-type" ], "Point" ]
+      icon-image: pinhead:gravestone
+      icon-overlap: always
+      icon-color: gray
+      icon-halo-color: yellow
+      icon-halo-width: 2
+      icon-opacity:
+        - interpolate
+        - [ exponential, 2 ]
+        - [ zoom ]
+        - 18
+        - 1
+        - 20.5
+        - 0.2
+      icon-size:
+        - interpolate
+        - [ exponential, 2 ]
+        - [ zoom ]
+        - 15
+        - 0.4
+        - 22
+        - 8
+
+controls:
+  - type: GeolocateControl
+    options:
+      positionOptions:
+        enableHighAccuracy: true
+      trackUserLocation: true
+
+popupTemplate: >
+  <div style="max-width: 25em; overflow-wrap: break-word; font-family:
+  sans-serif;"> {% if tags.name %}
+    <h2> {{tags.name }} </h2>
+  {% endif %}  {% if tags.wikimedia_commons %}
+    <a href="https://commons.wikimedia.org/wiki/{{ tags.wikimedia_commons }}" target="_blank">
+      <img style="width: 100%; max-width: 25em; height: auto; max-height: 25em; object-fit: contain; display: block;" src="https://commons.wikimedia.org/wiki/Special:FilePath/{{ tags.wikimedia_commons | remove: 'File:' | remove: 'file' }}">
+    </a>
+  {% endif %} {% if tags.inscription %}
+    {{tags.inscription }} <br>
+  {% endif %}  {% if tags["subject:wikipedia"] %}
+      {% assign lang = tags["subject:wikipedia"] | split: ":" | first %}
+      <a href="https://{{ lang }}.wikipedia.org/wiki/{{ tags["subject:wikipedia"] | replace_first: lang, "" | replace_first: ":", "" }}" target="_blank">Read about me on Wikipedia</a><br>
+  {% endif %} {% if tags.mapillary %}
+     <a href="https://www.mapillary.com/app/?focus=photo&pKey={{ tags.mapillary }}"
+  target="_blank">View Grave at Street Level</a><br> {% endif %} <br> <a
+  href="https://openstreetmap.org/{{ type }}/{{ id }}" target="_blank">View on
+  OSM</a> <br> <a href="https://openstreetmap.org/edit?{{ type }}={{ id }}"
+  target="_blank">Edit on OSM</a> <details> <summary>OSM Tags</summary> {%- for
+  tag in tags %}
+    {%- if tag[0] contains "wikidata" %}
+      <code>{{ tag[0] }} = <a href="https://wikidata.org/wiki/{{ tag[1] }}" target="_blank">{{ tag[1] }}</a></code>
+    {%- elsif tag[0] contains "wikipedia" %}
+      {% assign lang = tag[1] | split: ":" | first %}
+      <code>{{ tag[0] }} = <a href="https://{{ lang }}.wikipedia.org/wiki/{{ tag[1] | replace_first: lang, "" | replace_first: ":", "" }}" target="_blank">{{ tag[1] }}</a></code>
+    {%- elsif tag[0] contains "wikimedia_commons" %}
+      <code>{{ tag[0] }} = <a href="https://commons.wikimedia.org/wiki/{{ tag[1] }}" target="_blank">{{ tag[1] }}</a></code>
+    {%- elsif tag[0] contains "_is" %}
+    {%- else %}
+      <code>{{ tag[0] }} = {{ tag[1] }}</code>
+    {%- endif %}
+    <br>
+  {%- endfor %} </details> </div>
+---
+area[wikidata=Q109237418] -> .east_end;
+area[wikidata=Q5417189] -> .evergreen;
+area[wikidata=Q139279400] -> .paupers;
+(
+  node[cemetery=grave](area.east_end);
+  node[cemetery=grave](area.evergreen);
+  node[cemetery=grave](area.paupers);
+);
+out geom;
+(
+  way[wikidata=Q109237418];
+  way[wikidata=Q5417189];
+  way[wikidata=Q139279400];
+);
+out geom;

--- a/src/content/ultra-maps/cemeteries-shockoe-hill.ultra
+++ b/src/content/ultra-maps/cemeteries-shockoe-hill.ultra
@@ -3,10 +3,21 @@ server: https://overpass.maprva.org/api
 options:
   zoom: 17.5
   center: [ -77.432, 37.552 ]
+  bearing: 37.5
 style:
   layers:
   - type: symbol
     icon-image: pinhead:gravestone
+    icon-overlap: always
+    icon-size:
+      - interpolate
+      - [exponential, 2]
+      - [zoom]
+      - 16
+      - .125
+      - 22
+      - 8
+    
 popupTemplate: >
   <div style="max-width: 25em; overflow-wrap: break-word; font-family: sans-serif;">
   {% if tags.name %}

--- a/src/content/ultra-maps/cemeteries-shockoe-hill.ultra
+++ b/src/content/ultra-maps/cemeteries-shockoe-hill.ultra
@@ -1,0 +1,52 @@
+---
+server: https://overpass.maprva.org/api
+options:
+  zoom: 17.5
+  center: [ -77.432, 37.552 ]
+style:
+  layers:
+  - type: symbol
+    icon-image: pinhead:gravestone
+popupTemplate: >
+  <div style="max-width: 25em; overflow-wrap: break-word; font-family: sans-serif;">
+  {% if tags.name %}
+    <h2> {{tags.name }} </h2>
+  {% endif %} 
+  {% if tags.wikimedia_commons %}
+    <a href="https://commons.wikimedia.org/wiki/{{ tags.wikimedia_commons }}" target="_blank">
+      <img style="width: 100%; max-width: 25em; height: auto; max-height: 25em; object-fit: contain; display: block;" src="https://commons.wikimedia.org/wiki/Special:FilePath/{{ tags.wikimedia_commons | remove: 'File:' | remove: 'file' }}">
+    </a>
+  {% endif %}
+  {% if tags.inscription %}
+    {{tags.inscription }} <br>
+  {% endif %} 
+  {% if tags["subject:wikipedia"] %}
+      {% assign lang = tags["subject:wikipedia"] | split: ":" | first %}
+      <a href="https://{{ lang }}.wikipedia.org/wiki/{{ tags["subject:wikipedia"] | replace_first: lang, "" | replace_first: ":", "" }}" target="_blank">Read about me on Wikipedia</a><br>
+  {% endif %}
+  {% if tags.mapillary %}
+     <a href="https://www.mapillary.com/app/?focus=photo&pKey={{ tags.mapillary }}"
+  target="_blank">View Grave at Street Level</a><br>
+  {% endif %}
+  <br>
+  <a href="https://openstreetmap.org/{{ type }}/{{ id }}"
+  target="_blank">View on OSM</a> <br> <a
+  href="https://openstreetmap.org/edit?{{ type }}={{ id }}" target="_blank">Edit
+  on OSM</a> <details> <summary>OSM Tags</summary> {%- for tag in tags %}
+    {%- if tag[0] contains "wikidata" %}
+      <code>{{ tag[0] }} = <a href="https://wikidata.org/wiki/{{ tag[1] }}" target="_blank">{{ tag[1] }}</a></code>
+    {%- elsif tag[0] contains "wikipedia" %}
+      {% assign lang = tag[1] | split: ":" | first %}
+      <code>{{ tag[0] }} = <a href="https://{{ lang }}.wikipedia.org/wiki/{{ tag[1] | replace_first: lang, "" | replace_first: ":", "" }}" target="_blank">{{ tag[1] }}</a></code>
+    {%- elsif tag[0] contains "wikimedia_commons" %}
+      <code>{{ tag[0] }} = <a href="https://commons.wikimedia.org/wiki/{{ tag[1] }}" target="_blank">{{ tag[1] }}</a></code>
+    {%- elsif tag[0] contains "_is" %}
+    {%- else %}
+      <code>{{ tag[0] }} = {{ tag[1] }}</code>
+    {%- endif %}
+    <br>
+  {%- endfor %} </details> </div>
+---
+area[wikidata=Q3959678] -> .shockoe_cemetery;
+node[cemetery=grave](area.shockoe_cemetery);
+out geom;

--- a/src/content/ultra-maps/cemeteries-shockoe-hill.ultra
+++ b/src/content/ultra-maps/cemeteries-shockoe-hill.ultra
@@ -5,45 +5,58 @@ options:
   center: [ -77.432, 37.552 ]
   bearing: 37.5
 style:
+  extends: https://styles.maprva.org/henrico-aerial-imagery-latest.json
   layers:
-  - type: symbol
-    icon-image: pinhead:gravestone
-    icon-overlap: always
-    icon-size:
-      - interpolate
-      - [exponential, 2]
-      - [zoom]
-      - 16
-      - .125
-      - 22
-      - 8
-    
+    - type: symbol
+      icon-image: pinhead:gravestone
+      icon-overlap: always
+      icon-color: gray
+      icon-halo-color: yellow
+      icon-halo-width: 2 
+      icon-opacity:
+        - interpolate
+        - [ exponential, 2 ]
+        - [ zoom ]
+        - 18
+        - 1
+        - 20.5
+        - 0.2
+      icon-size:
+        - interpolate
+        - [ exponential, 2 ]
+        - [ zoom ]
+        - 16
+        - 0.125
+        - 22
+        - 8
+
+controls:
+  - type: GeolocateControl
+    options:
+      positionOptions:
+        enableHighAccuracy: true
+      trackUserLocation: true
+      
 popupTemplate: >
-  <div style="max-width: 25em; overflow-wrap: break-word; font-family: sans-serif;">
-  {% if tags.name %}
+  <div style="max-width: 25em; overflow-wrap: break-word; font-family:
+  sans-serif;"> {% if tags.name %}
     <h2> {{tags.name }} </h2>
-  {% endif %} 
-  {% if tags.wikimedia_commons %}
+  {% endif %}  {% if tags.wikimedia_commons %}
     <a href="https://commons.wikimedia.org/wiki/{{ tags.wikimedia_commons }}" target="_blank">
       <img style="width: 100%; max-width: 25em; height: auto; max-height: 25em; object-fit: contain; display: block;" src="https://commons.wikimedia.org/wiki/Special:FilePath/{{ tags.wikimedia_commons | remove: 'File:' | remove: 'file' }}">
     </a>
-  {% endif %}
-  {% if tags.inscription %}
+  {% endif %} {% if tags.inscription %}
     {{tags.inscription }} <br>
-  {% endif %} 
-  {% if tags["subject:wikipedia"] %}
+  {% endif %}  {% if tags["subject:wikipedia"] %}
       {% assign lang = tags["subject:wikipedia"] | split: ":" | first %}
       <a href="https://{{ lang }}.wikipedia.org/wiki/{{ tags["subject:wikipedia"] | replace_first: lang, "" | replace_first: ":", "" }}" target="_blank">Read about me on Wikipedia</a><br>
-  {% endif %}
-  {% if tags.mapillary %}
+  {% endif %} {% if tags.mapillary %}
      <a href="https://www.mapillary.com/app/?focus=photo&pKey={{ tags.mapillary }}"
-  target="_blank">View Grave at Street Level</a><br>
-  {% endif %}
-  <br>
-  <a href="https://openstreetmap.org/{{ type }}/{{ id }}"
-  target="_blank">View on OSM</a> <br> <a
-  href="https://openstreetmap.org/edit?{{ type }}={{ id }}" target="_blank">Edit
-  on OSM</a> <details> <summary>OSM Tags</summary> {%- for tag in tags %}
+  target="_blank">View Grave at Street Level</a><br> {% endif %} <br> <a
+  href="https://openstreetmap.org/{{ type }}/{{ id }}" target="_blank">View on
+  OSM</a> <br> <a href="https://openstreetmap.org/edit?{{ type }}={{ id }}"
+  target="_blank">Edit on OSM</a> <details> <summary>OSM Tags</summary> {%- for
+  tag in tags %}
     {%- if tag[0] contains "wikidata" %}
       <code>{{ tag[0] }} = <a href="https://wikidata.org/wiki/{{ tag[1] }}" target="_blank">{{ tag[1] }}</a></code>
     {%- elsif tag[0] contains "wikipedia" %}


### PR DESCRIPTION
This PR adds a cemeteries project page, currently unlisted as I haven't made a logo.

Idea is to have a series of open-data/open-source-tool cemetery maps, which is of different intent and scope than, say, the Cemetery Collaboratory.

Quick links to Ultra maps:
[Shockoe Hill](https://ultra.maprva.org/?query=url:https://raw.githubusercontent.com/MapRVA/maprva.org/abf27c054d46b1c899aeee289a20ba156982f1e4/src/content/ultra-maps/cemeteries-shockoe-hill.ultra)
[East End cemeteries](https://ultra.maprva.org/?query=https://github.com/MapRVA/maprva.org/blob/abf27c054d46b1c899aeee289a20ba156982f1e4/src/content/ultra-maps/cemeteries-east-ends.ultra)